### PR TITLE
Accept ssa/ass subtitles as well

### DIFF
--- a/ffmulticonverter/audiovideotab.py
+++ b/ffmulticonverter/audiovideotab.py
@@ -296,7 +296,7 @@ class AudioVideoTab(QWidget):
         Get the filename using standard QtDialog and update embedQLE's text.
         """
         fname = QFileDialog.getOpenFileName(self, 'FF Multi Converter - ' +
-                self.tr('Choose File'), config.home, 'Subtitles (*.srt *.sub)')
+                self.tr('Choose File'), config.home, 'Subtitles (*.srt *.sub *.ssa *.ass)')
         if fname:
             self.embedQLE.setText(fname)
 


### PR DESCRIPTION
-vf "subtitles='/path/to/subtitle'" can actually accept ssa/ass subtitles as long as you compile ffmpeg with libass support. In many distributions (like Ubuntu and Arch Linux or even more) this option is enabled in official ffmpeg package.

I have tested with mkv video and ass subtitle, works perfect.